### PR TITLE
WP-1953-bullseye-key-dev-distro

### DIFF
--- a/distributions
+++ b/distributions
@@ -17,7 +17,7 @@ Components: main
 Description: Development Tools Repository
 Uploaders: uploaders
 Contents: .gz
-SignWith: 527FBC6A
+SignWith: 19121AED
 Update: wazo-dev-bullseye-partial-tools
 
 Origin: Wazo
@@ -27,7 +27,7 @@ Components: main
 Description: Asterisk release candidate
 Uploaders: uploaders
 Contents: .gz
-SignWith: 527FBC6A
+SignWith: 19121AED
 
 Origin: Wazo
 Codename: wazo-rc


### PR DESCRIPTION
why: they are dev distribution that should be signed with the latest
available key
The old one, it about to expire anyways ...
