### PR TITLE
WAZO-4364-backport-typing-extensions

### DIFF
--- a/bookworm-backports.list
+++ b/bookworm-backports.list
@@ -1,0 +1,1 @@
+python-typing-extensions install

--- a/distributions
+++ b/distributions
@@ -202,7 +202,7 @@ Codename: wazo-dev-bookworm
 Label: wazo-dev-bookworm
 Architectures: amd64 source
 Components: main
-Update: trixie-partial
+Update: bookworm-backports trixie-partial
 Description: Wazo Development Version
 Uploaders: uploaders
 Contents: .gz

--- a/updates
+++ b/updates
@@ -92,6 +92,15 @@ Architectures: i386 amd64 source
 VerifyRelease: 386FA1D9 | 2643E131
 FilterSrcList: deinstall bullseye-backports.list
 
+Name: bookworm-backports
+Method: http://archive.debian.org/debian
+Suite: bookworm-backports
+Components: main
+Architectures: i386 amd64 source
+# FTP master keys. See https://ftp-master.debian.org/keys.html
+VerifyRelease: 2643E131
+FilterSrcList: deinstall bookworm-backports.list
+
 Name: bookworm-partial
 Method: http://ftp.ca.debian.org/debian
 Suite: bookworm


### PR DESCRIPTION
why: graphene needs version >=4.7 and bookworm has 4.4
